### PR TITLE
[fix] order body parse

### DIFF
--- a/scripts/lib/abstractRoute.ts
+++ b/scripts/lib/abstractRoute.ts
@@ -125,7 +125,7 @@ export interface BuilderPatternAbstractRoute<
 	): Omit<BuilderPatternAbstractRoute<request, response, extractObj>, "hook" | "access">;
 
 	extract(
-		extractObj: extractObj,
+		extractObj: Omit<extractObj, "body">,
 		error?: ErrorExtractAbstractRouteFunction<response>
 	): Omit<BuilderPatternAbstractRoute<request, response, extractObj>, "hook" | "extract" | "access">;
 
@@ -143,7 +143,7 @@ export interface BuilderPatternAbstractRoute<
 
 	handler(handlerFunction: AbstractRouteHandlerFunction<response>): Omit<BuilderPatternAbstractRoute<request, response, extractObj>, "hook" | "extract" | "access" | "check" | "process" | "cut" | "handler">;
 	
-	build<drop extends string, options extends any>(buildAbstractRouteParameters?: BuildAbstractRouteParameters<drop, options>): UseAbstractRoute<drop, options, request, response>;
+	build<drop extends string, options extends any>(buildAbstractRouteParameters?: BuildAbstractRouteParameters<drop, options>): UseAbstractRoute<drop, options, request, response, extractObj>;
 }
 
 export default function makeAbstractRoutesSystem(declareRoute: DeclareRoute, serverHooksLifeCycle: ServerHooksLifeCycle){

--- a/scripts/lib/process.ts
+++ b/scripts/lib/process.ts
@@ -95,16 +95,17 @@ export interface BuilderPatternProcess<
 
 	handler(handlerFunction: ProcessHandlerFunction<response>): Omit<BuilderPatternProcess<request, response, extractObj>, "hook" | "extract" | "check" | "process" | "handler" | "cut">;
 	
-	build<drop extends string, input extends any, options extends any>(buildProcessParameters?: BuildProcessParameters<drop, input, options>): ProcessExport<drop, input, options>;
+	build<drop extends string, input extends any, options extends any>(buildProcessParameters?: BuildProcessParameters<drop, input, options>): ProcessExport<drop, input, options, extractObj>;
 }
 
-export interface ProcessExport<drop = string, input = any, options = any>{
+export interface ProcessExport<drop = string, input = any, options = any, extractObj = ProcessExtractObj>{
 	name: string;
 	options?: options;
 	processFunction: ProcessFunction;
 	drop?: drop[];
 	hooksLifeCyle: ReturnType<typeof makeHooksLifeCycle>;
 	input?: (pickup: ReturnType<typeof makeFloor>["pickup"]) => input;
+	extracted: extractObj
 }
 
 export type ProcessFunction = (request: Request, response: Response, options: any, input: any) => Record<string, any> | Promise<Record<string, any>>;
@@ -306,6 +307,7 @@ export default function makeProcessSystem(serverHooksLifeCycle: ServerHooksLifeC
 				drop: buildProcessParameters?.drop,
 				processFunction,
 				hooksLifeCyle,
+				extracted,
 			};
 		};
 

--- a/scripts/lib/route.ts
+++ b/scripts/lib/route.ts
@@ -360,6 +360,10 @@ export default function makeRoutesSystem(
 							)
 					),
 					condition(
+						!!extracted.body,
+						() => hookBody()
+					),
+					condition(
 						Object.keys(extracted).length !== 0,
 						() => extractedTry(
 							mapped(
@@ -519,11 +523,6 @@ const routeFunctionString = (async: boolean, block: string) => /* js */`
 		await this.hooks.launchOnConstructRequest(request);
 		await this.hooks.launchOnConstructResponse(response);
 
-		if(/^(?:POST|PUT|PATCH)$/.test(request.method)){
-			await this.hooks.launchBeforeParsingBody(request, response);
-			if(request.body === undefined)await this.parseContentTypeBody(request);
-		}
-
 		try {
 			try{
 				const floor = this.makeFloor();
@@ -579,6 +578,11 @@ result = ${async ? "await " : ""}this.grapAccess.processFunction(
 );
 
 ${drop}
+`;
+
+const hookBody = () => /* js */`
+await this.hooks.launchBeforeParsingBody(request, response);
+if(request.body === undefined)await this.parseContentTypeBody(request);
 `;
 
 const extractedTry = (block: string) => /* js */`

--- a/test/abstractRoute.ts
+++ b/test/abstractRoute.ts
@@ -22,6 +22,7 @@ interface textEx extends RouteExtractObj{
 const mustBeConnected = duplo.declareAbstractRoute<RequestTest, Response, textEx>("mustBeConnected")
 .hook("onConstructRequest", (request) => console.log("abstract hook"))
 .access((floor, request, response) => {request.cookies;})
+.extract({})
 .cut((floor, response) => {
 	floor.drop("test", floor.pickup("options"));
 })
@@ -38,6 +39,7 @@ const deepAbstractRoute = mustBeConnected({pickup: ["test"], options: {test: fal
 	request.cookies;
 	request.toto;
 })
+.extract({})
 .cut((floor) => floor.drop("deep", "deep ABS"))
 .build({drop: ["test", "deep"], prefix: "deep"});
 
@@ -45,6 +47,7 @@ deepAbstractRoute({pickup: ["test", "deep"], ignorePrefix: true})
 .declareRoute<RequestTest3>("GET", "/api")
 .hook("onConstructRequest", () => console.log("local hook"))
 .access((floor, request, response) => {request.cookies;})
+.extract({})
 .handler((floor, response) => {
 	const options = floor.pickup("test");
 	options.deep = floor.pickup("deep");


### PR DESCRIPTION
les hook de parse du body on étais placer après l'exécution de l'abstract route et du l'access. ils seront mis dans la fonction uniquement si la clé body apparaît dans l'extract.